### PR TITLE
Add Alberta planning subregions to available study areas

### DIFF
--- a/LandWeb_preamble.R
+++ b/LandWeb_preamble.R
@@ -96,6 +96,12 @@ Init <- function(sim) {
                url = "https://drive.google.com/open?id=1OH3b5pwjumm1ToytDBDI6jthVe2pp0tS", # 2020-06
                columnNameForLabels = "FMU_NAME", isStudyArea = FALSE, filename2 = NULL)
 
+  ## AB Planning Subregion boundaries
+  ml <-  mapAdd(map = ml, layerName = "ab_planning_subregions",
+                useSAcrs = TRUE, poly = TRUE, overwrite = TRUE,
+                url = "https://drive.google.com/file/d/1vxbNiftvzP0B_B3tm68pNNccGC2PkWQc", # 2020-10
+                columnNameForLabels = "SUBR_NAME", isStudyArea = FALSE, filename2 = NULL)
+
   ### Rename some polygons:
   ###   - DMI is now Mercer (MPR)
   ids <- grep("Daishowa-Marubeni International Ltd", ml[["FMA Boundaries Updated"]][["Name"]])
@@ -176,6 +182,12 @@ Init <- function(sim) {
     ml <- provNWT(ml, P(sim)$runName, dataDir, sim$canProvs, P(sim)$bufferDist, asStudyArea = TRUE)
   } else if (grepl("provSK", P(sim)$runName)) {
     ml <- provSK(ml, P(sim)$runName, dataDir, sim$canProvs, P(sim)$bufferDist, asStudyArea = TRUE)
+  } else if (grepl("Smoky", P(sim)$runName)) {
+    ml <- processPSR(ml, config::get('studyarea'), dataDir, sim$canProvs, P(sim)$bufferDist, asStudyArea = TRUE)
+  } else if (grepl("Bistcho", P(sim)$runName)) {
+    ml <- processPSR(ml, config::get('studyarea'), dataDir, sim$canProvs, P(sim)$bufferDist, asStudyArea = TRUE)
+  } else if (grepl("Cold", P(sim)$runName)) {
+    ml <- processPSR(ml, config::get('studyarea'), dataDir, sim$canProvs, P(sim)$bufferDist, asStudyArea = TRUE)
   } else {
     ## use a small random study area
     message(crayon::red("Using random study area for runName", runName))

--- a/R/planningRegionsAB.R
+++ b/R/planningRegionsAB.R
@@ -1,0 +1,53 @@
+processPSR <- function(ml, study_area_name, dataDir, canProvs, bufferDist, asStudyArea = FALSE) {
+  ab <- canProvs[canProvs$NAME_1 == "Alberta", ]
+  psr <- extractPSR(ml, study_area_name)                                                # extractPSR
+  shapefile(psr, filename = file.path(dataDir, paste0(study_area_name, ".shp")), overwrite = TRUE)
+
+  ## reportingPolygons
+  psr.ansr <- postProcess(ml[["Alberta Natural Subregions"]],
+                          studyArea = psr, useSAcrs = TRUE,
+                          filename2 = file.path(dataDir, paste0(study_area_name, "_ANSR.shp")),
+                          overwrite = TRUE) %>%
+    joinReportingPolygons(., psr)
+  psr.caribou <- postProcess(ml[["LandWeb Caribou Ranges"]],
+                             studyArea = psr, useSAcrs = TRUE,
+                             filename2 = file.path(dataDir, paste0(study_area_name, "_caribou.shp")),
+                             overwrite = TRUE) %>%
+    joinReportingPolygons(., psr)
+  psr.caribou.joined <- SpatialPolygonsDataFrame(aggregate(psr.caribou),
+                                                 data.frame(Name = "Caribou",
+                                                            shinyLabel = "Caribou",
+                                                            stringsAsFactors = FALSE)) %>%
+    joinReportingPolygons(., psr)
+
+  ml <- mapAdd(psr, ml, layerName = study_area_name, useSAcrs = TRUE, poly = TRUE,
+               analysisGroupReportingPolygon = study_area_name, isStudyArea = isTRUE(asStudyArea),
+               columnNameForLabels = "Name", filename2 = NULL)
+  ml <- mapAdd(psr.ansr, ml, layerName = paste0(study_area_name, " ANSR"), useSAcrs = TRUE, poly = TRUE,
+               analysisGroupReportingPolygon = paste0(study_area_name, " ANSR"),
+               columnNameForLabels = "Name", filename2 = NULL)
+  ml <- mapAdd(psr.caribou, ml, layerName = paste0(study_area_name, " Caribou"), useSAcrs = TRUE, poly = TRUE,
+               analysisGroupReportingPolygon = paste0(study_area_name, " Caribou"),
+               columnNameForLabels = "Name", filename2 = NULL)
+  ml <- mapAdd(psr.caribou.joined, ml, layerName = paste0(study_area_name, " Caribou Joined"), useSAcrs = TRUE, poly = TRUE,
+               analysisGroupReportingPolygon = paste0(study_area_name, " Caribou Joined"),
+               columnNameForLabels = "Name", filename2 = NULL)
+
+  ## studyArea shouldn't use analysisGroup because it's not a reportingPolygon
+  psr_sr <- postProcess(ml[["LandWeb Study Area"]],
+                        studyArea = amc::outerBuffer(psr, bufferDist),
+                        useSAcrs = TRUE,
+                        filename2 = file.path(dataDir, paste0(study_area_name, "_SR.shp")),
+                        overwrite = TRUE)
+
+  plotPSR(psr, provs = ab, caribou = psr.caribou, xsr = psr_sr, title = study_area_name,  #plotPSR
+          png = file.path(dataDir, paste0(study_area_name, ".png")))
+
+  if (isTRUE(asStudyArea)) {
+    ml <- mapAdd(psr_sr, ml, isStudyArea = TRUE, layerName = paste0(study_area_name, " SR"),
+                 useSAcrs = TRUE, poly = TRUE, studyArea = NULL, # don't crop/mask to studyArea(ml, 2)
+                 columnNameForLabels = "NSN", filename2 = NULL)
+  }
+
+  return(ml)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -157,3 +157,58 @@ plotGG <- function(x, provs, caribou = NULL, png = NULL) {
 
   return(x_gg)
 }
+
+#' Extract boundary polygon(s) for planning subregion(s)
+#'
+#' @param ml    A \code{map} object containing 'ab_planning_subregions'
+#'              \code{SpatialPolygonsDataFrame} object with planning subregion boundaries
+#'
+#' @param name  A character (regex) string to match.
+#'
+#' @return \code{SpatialPolygonsDataFrame}
+#'
+#' @export
+#'
+extractPSR <- function(ml, name) {
+  if (is.null(ml[["ab_planning_subregions"]])) stop("'ab_planning_subregions' not found")
+  ml[["ab_planning_subregions"]][grepl(name, ml[["ab_planning_subregions"]][["Name"]]), ]
+}
+
+#' Plot boundary polygon(s) for Alberta planning subregions
+#'
+#' @param x        \code{SpatialPolygons*} object corresponding to the subregion to be plotted
+#'
+#' @param provs    \code{SpatialPolygons*} object corresponding to the provincial
+#'                 (or territorial) boundaries to plot
+#'
+#' @param caribou  Optional \code{SpatialPolygons*} object corresponding to caribou boundaries
+#'
+#' @param xsr      Optional \code{SpatialPolygons*} object corresponding to a buffered \code{studyArea}
+#'
+#' @param title    Character string to use for plot title
+#'
+#' @param png      Optional. If non-NULL, must be a valid file path to a write a png
+#'
+#' @export
+#' @importFrom graphics dev.off png
+#' @importFrom sp crs plot spTransform
+#' @rdname plotFMA
+plotPSR <- function(x, provs, caribou = NULL, xsr = NULL, title = NULL, png = NULL) {
+  provs <- spTransform(provs, crs(x))
+
+  ## regular boring old plot
+  if (!is.null(png)) png(filename = png, width = 1200, height = 800)
+  sp::plot(provs)
+  sp::plot(x[, "Name"], main = title, col = "lightblue", add = TRUE)
+  if (!is.null(caribou)) sp::plot(caribou, col = "magenta", add = TRUE)
+  if (!is.null(xsr)) sp::plot(xsr, add = TRUE)
+  if (!is.null(png)) dev.off()
+
+  ## sexy ggplot version
+  x_gg <- plotGG(x, provs, caribou, png)
+
+  if (!is.null(png)) {
+    png2 <- gsub("[.]png", "_gg.png", png)
+    ggsave(png2, x_gg, width = 6, height = 8) ## a bit slow...
+  }
+}


### PR DESCRIPTION
Code was added to allow users to select subregions of Alberta used in land-use planning as study areas to run LandWeb. Study areas can be selected by their names: 'Smoky', 'Cold', and 'Bistcho'.